### PR TITLE
fix: handle multiple begin/end blocks in n8n streaming

### DIFF
--- a/custom_components/webhook_conversation/entity.py
+++ b/custom_components/webhook_conversation/entity.py
@@ -152,13 +152,16 @@ class WebhookConversationLLMBaseEntity(WebhookConversationBaseEntity):
                     if line_str:
                         try:
                             chunk_data = json.loads(line_str)
-                            if (
-                                chunk_data.get("type") == "item"
-                                and "content" in chunk_data
-                            ):
+                            chunk_type = chunk_data.get("type")
+                            if chunk_type == "item" and "content" in chunk_data:
                                 yield chunk_data["content"]
-                            elif chunk_data.get("type") == "end":
-                                break
+                            elif chunk_type == "error":
+                                raise HomeAssistantError(
+                                    f"n8n error: {chunk_data.get('message', chunk_data)}"
+                                )
+                            # We don't break on "end" because n8n can send multiple
+                            # begin/end blocks when using tools or intermediate steps.
+                            # We keep reading until the stream actually closes.
                         except json.JSONDecodeError:
                             _LOGGER.warning(
                                 "Failed to parse streaming response chunk: %s", line_str


### PR DESCRIPTION
Remove premature break on 'end' chunk type to support multi-step n8n agent workflows and add error chunk handling.

Seems to be working as intended now on my own HASS instance. n8n structuredChunk definition can be found in: https://github.com/n8n-io/n8n/blob/bb7d137cf735bcdf65bbcf8ff58fa911d83121f5/packages/workflow/src/interfaces.ts#L3612

Fixes #38 